### PR TITLE
xDrip-plus support and more

### DIFF
--- a/Application/src/main/AndroidManifest.xml
+++ b/Application/src/main/AndroidManifest.xml
@@ -38,6 +38,8 @@
 
         <activity android:name=".nightscout.NightscoutPreferences" />
 
+        <activity android:name=".xdrip_plus.XdripPlusPreferences" />
+
         <activity android:name=".Preferences" />
 
     </application>

--- a/Application/src/main/java/com/pimpimmobile/librealarm/MainActivity.java
+++ b/Application/src/main/java/com/pimpimmobile/librealarm/MainActivity.java
@@ -40,6 +40,7 @@ import com.pimpimmobile.librealarm.shareddata.PreferencesUtil;
 import com.pimpimmobile.librealarm.shareddata.Status;
 import com.pimpimmobile.librealarm.shareddata.Status.Type;
 import com.pimpimmobile.librealarm.shareddata.WearableApi;
+import com.pimpimmobile.librealarm.xdrip_plus.XdripPlusPreferences;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -141,6 +142,7 @@ public class MainActivity extends Activity implements WearService.WearServiceLis
         mTriggerGlucoseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                mProgressBar.setVisibility(View.VISIBLE);
                 mService.sendMessage(WearableApi.TRIGGER_GLUCOSE, "", null);
             }
         });
@@ -302,6 +304,9 @@ public class MainActivity extends Activity implements WearService.WearServiceLis
         if (item.getItemId() == R.id.nightscout) {
             startActivity(new Intent(this, NightscoutPreferences.class));
         }
+        if (item.getItemId() == R.id.xdrip_plus) {
+            startActivityForResult(new Intent(this, XdripPlusPreferences.class),0);
+        }
         if (item.getItemId() == R.id.preferences) {
             startActivityForResult(new Intent(this, Preferences.class), 0);
         }
@@ -357,6 +362,12 @@ public class MainActivity extends Activity implements WearService.WearServiceLis
             mStatusTextView.setText(R.string.status_message_first_startup);
         } else {
             mStatusTextView.setText(mService.getStatusString());
+            // TODO add layout item for battery instead of using append
+            if (mService.getBatteryLevel()>0) mStatusTextView.append(" Batt: "+mService.getBatteryLevel()+"%");
+            if ((status!=null)&& (status.status == Type.ATTEMPTING) && (!status.hasRoot)) mStatusTextView.append(" needs SuperSU patch!");
+            // simple indicator of root status, supersu root for wear is available at:
+            // http://forum.xda-developers.com/attachment.php?attachmentid=3342605&d=1433157678
+            // sha1: 00c2ccd6ff356fa5cf73124e978fc192af186d2d
         }
 
         updateAlarmSnoozeViews();

--- a/Application/src/main/java/com/pimpimmobile/librealarm/WearService.java
+++ b/Application/src/main/java/com/pimpimmobile/librealarm/WearService.java
@@ -35,6 +35,7 @@ import com.pimpimmobile.librealarm.shareddata.PreferencesUtil;
 import com.pimpimmobile.librealarm.shareddata.ReadingData;
 import com.pimpimmobile.librealarm.shareddata.Status;
 import com.pimpimmobile.librealarm.shareddata.WearableApi;
+import com.pimpimmobile.librealarm.xdrip_plus.XdripPlusBroadcast;
 
 import java.nio.charset.Charset;
 import java.util.Date;
@@ -117,6 +118,7 @@ public class WearService extends Service implements DataApi.DataListener, Messag
                 mDatabase.storeReading(object.data);
                 WearableApi.sendMessage(mGoogleApiClient, WearableApi.GLUCOSE, String.valueOf(object.id), null);
                 if (mListener != null) mListener.onDataUpdated();
+                if (PreferencesUtil.isXdripPlusEnabled(this)) XdripPlusBroadcast.syncXdripPlus(getApplicationContext(),data,object,getBatteryLevel());
                 if (PreferencesUtil.isNsRestEnabled(this)) syncNightscout();
                 runTextToSpeech(object.data.prediction);
                 break;
@@ -341,6 +343,14 @@ public class WearService extends Service implements DataApi.DataListener, Messag
             mTextToSpeech.speak(message, TextToSpeech.QUEUE_FLUSH, null, "glucose-speech");
         }
 
+    }
+
+    public int getBatteryLevel() {
+        if ((mReadingStatus != null) && (mReadingStatus.battery > 0)) {
+            return mReadingStatus.battery;
+        } else {
+            return 0;
+        }
     }
 
     public String getStatusString() {

--- a/Application/src/main/java/com/pimpimmobile/librealarm/xdrip_plus/XdripPlusBroadcast.java
+++ b/Application/src/main/java/com/pimpimmobile/librealarm/xdrip_plus/XdripPlusBroadcast.java
@@ -1,0 +1,47 @@
+package com.pimpimmobile.librealarm.xdrip_plus;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.pimpimmobile.librealarm.shareddata.ReadingData;
+
+import java.util.List;
+
+/**
+ * Created by jamorham on 08/09/2016.
+ */
+
+public class XdripPlusBroadcast {
+
+    final static String TAG = "LibAlrm+xDrip+bcast";
+
+    // send broadcast to xDrip-plus
+    public static void syncXdripPlus(final Context context, final String data, final ReadingData.TransferObject object, final int battery_level) {
+        final boolean check_receivers = true;
+        new Thread() {
+            @Override
+            public void run() {
+                final String LIBRE_ALARM_TO_XDRIP_PLUS = "com.eveningoutpost.dexdrip.FROM_LIBRE_ALARM";
+                final Bundle bundle = new Bundle();
+
+                bundle.putInt("bridge_battery", battery_level);
+                bundle.putString("data", data);
+
+                final Intent intent = new Intent(LIBRE_ALARM_TO_XDRIP_PLUS);
+                intent.putExtras(bundle);
+                intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
+                context.sendBroadcast(intent);
+                List<ResolveInfo> q = context.getPackageManager().queryBroadcastReceivers(intent, 0);
+                // can use this to generate an alert if nothing there to receive the data
+                if (check_receivers) {
+                    if (q.size() < 1) {
+                        Log.e(TAG, "xDrip-plus No receivers! - xDrip-plus not running or out of date version?");
+                    } else Log.e(TAG, "Sent to xDrip-plus " + q.size() + " receivers");
+                }
+            }
+        }.start();
+    }
+}

--- a/Application/src/main/java/com/pimpimmobile/librealarm/xdrip_plus/XdripPlusPreferences.java
+++ b/Application/src/main/java/com/pimpimmobile/librealarm/xdrip_plus/XdripPlusPreferences.java
@@ -1,0 +1,68 @@
+package com.pimpimmobile.librealarm.xdrip_plus;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+import android.preference.PreferenceManager;
+
+import com.pimpimmobile.librealarm.R;
+
+import java.util.HashMap;
+
+/**
+ * Created by jamorham on 06/09/2016.
+ */
+
+public class XdripPlusPreferences extends Activity implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    private HashMap<String, String> mChanged = new HashMap<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(this);
+        getFragmentManager().beginTransaction()
+                .replace(android.R.id.content, new SettingsFragment())
+                .commit();
+    }
+
+    public static class SettingsFragment extends PreferenceFragment {
+        @Override
+        public void onCreate(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+
+            // Load the preferences from an XML resource
+            addPreferencesFromResource(R.xml.xdrip_plus_preferences);
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        PreferenceManager.getDefaultSharedPreferences(this).unregisterOnSharedPreferenceChangeListener(this);
+        super.onDestroy();
+    }
+
+    @Override
+    public void onBackPressed() {
+        setResult();
+        super.onBackPressed();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        mChanged.put(key, sharedPreferences.getAll().get(key).toString());
+    }
+
+    private void setResult() {
+        Intent result = new Intent();
+        Bundle bundle = new Bundle();
+        for (String key : mChanged.keySet()) {
+            bundle.putString(key, mChanged.get(key));
+        }
+        result.putExtra("result", bundle);
+        setResult(RESULT_OK, result);
+    }
+}
+

--- a/Application/src/main/res/menu/menu.xml
+++ b/Application/src/main/res/menu/menu.xml
@@ -4,6 +4,8 @@
         android:title="@string/disclaimer_title" />
     <item android:id="@+id/nightscout"
         android:title="@string/nightscout" />
+    <item android:id="@+id/xdrip_plus"
+        android:title="@string/xdrip_plus"/>
     <item android:id="@+id/preferences"
         android:title="@string/preferences" />
 </menu>

--- a/Application/src/main/res/values/strings.xml
+++ b/Application/src/main/res/values/strings.xml
@@ -155,4 +155,7 @@
 
     <!-- Text-to-speech when we get an ERR -->
     <string name="text_to_speech_error">Failed to fetch glucose value</string>
+
+    <!-- xDrip+ -->
+    <string name="xdrip_plus" translatable="false">xDrip+</string>
 </resources>

--- a/Application/src/main/res/xml/preferences.xml
+++ b/Application/src/main/res/xml/preferences.xml
@@ -46,6 +46,7 @@
         <CheckBoxPreference
             android:key="@string/pref_key_disable_touchscreen"
             android:title="Completely disable watch touchscreen"
+            android:summaryOn="To re-enable touchscreen turn this off and hold watch button until it reboots"
             android:defaultValue="false" />
     </PreferenceCategory>
 

--- a/Application/src/main/res/xml/preferences.xml
+++ b/Application/src/main/res/xml/preferences.xml
@@ -35,4 +35,18 @@
             android:title="@string/settings_text_to_speech_only_alarm_title"
             android:defaultValue="false" />
     </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Power save features">
+        <CheckBoxPreference
+            android:key="@string/pref_key_clock_speed"
+            android:title="Slow down watch CPU"
+            android:summary="Run watch at slowest processing speed to save battery."
+            android:defaultValue="true" />
+        <CheckBoxPreference
+            android:key="@string/pref_key_disable_touchscreen"
+            android:title="Completely disable watch touchscreen"
+            android:defaultValue="false" />
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/Application/src/main/res/xml/xdrip_plus_preferences.xml
+++ b/Application/src/main/res/xml/xdrip_plus_preferences.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory android:title="xDrip+ broadcast">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="xdrip_plus_broadcast"
+            android:summary="Send data to xDrip+ running on the same handset" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/key_all_alarms_disabled"
+            android:summary="Disable all Watch and LibreAlarm alerts and use xDrip+ for alarms!" />
+    </PreferenceCategory>
+</PreferenceScreen>

--- a/Wearable/src/main/AndroidManifest.xml
+++ b/Wearable/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.pimpimmobile.librealarm">
 
-    <uses-sdk android:minSdkVersion="18" />
+    <uses-sdk android:minSdkVersion="21" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/Wearable/src/main/java/com/pimpimmobile/librealarm/DataLayerListenerService.java
+++ b/Wearable/src/main/java/com/pimpimmobile/librealarm/DataLayerListenerService.java
@@ -119,6 +119,7 @@ public class DataLayerListenerService extends WearableListenerService {
                 PreferencesUtil.setIsStarted(client.getContext(), false);
                 AlarmReceiver.stop(client.getContext());
                 sendStatus(client);
+                WearActivity.clearBusy();
             }
             break;
             case WearableApi.START: {

--- a/Wearable/src/main/java/com/pimpimmobile/librealarm/WearActivity.java
+++ b/Wearable/src/main/java/com/pimpimmobile/librealarm/WearActivity.java
@@ -8,6 +8,7 @@ import android.nfc.NfcManager;
 import android.nfc.Tag;
 import android.nfc.tech.NfcV;
 import android.os.AsyncTask;
+import android.os.BatteryManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
@@ -36,7 +37,12 @@ import com.pimpimmobile.librealarm.shareddata.Status;
 import com.pimpimmobile.librealarm.shareddata.Status.Type;
 import com.pimpimmobile.librealarm.shareddata.WearableApi;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 public class WearActivity extends Activity implements ConnectionCallbacks,
@@ -58,8 +64,15 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
 
     private Vibrator mVibrator;
 
+    private boolean hasRoot = false;
+    private boolean checkedForRoot = false;
+
+    private static boolean scripts_created = false;
+    private static final boolean d = true; // global debug output flag
     private static boolean busy = false;
     private static boolean tag_discovered = false;
+    private static int batteryLevel = -1;
+    private static Boolean nfcDestinationState = null;
 
     // We can't finish activity until all messages have been sent.
     private int mMessagesBeingSent;
@@ -111,6 +124,10 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
 
     private ReadingData mResult = new ReadingData(PredictionData.Result.ERROR_NO_NFC);
 
+    public static void clearBusy() {
+        busy = false;
+    }
+
     @Override
     public void onCreate(Bundle b) {
         super.onCreate(b);
@@ -129,6 +146,8 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
                         WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
         setContentView(R.layout.wear_activity);
 
+        createScripts();
+
         if (!busy) {
             busy = true;
             PowerManager manager = (PowerManager) getSystemService(POWER_SERVICE);
@@ -146,6 +165,9 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
             Log.d(TAG, "busy set true");
             rootSwitchNFC(true); // turn it on
 
+            BatteryManager bm = (BatteryManager)getSystemService(BATTERY_SERVICE);
+            batteryLevel = bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+
             mGoogleApiClient = new GoogleApiClient.Builder(this)
                     .addApi(Wearable.API)
                     .addConnectionCallbacks(this)
@@ -157,38 +179,48 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
             NfcManager nfcManager =
                     (NfcManager) WearActivity.this.getSystemService(Context.NFC_SERVICE);
             mNfcAdapter = nfcManager.getDefaultAdapter();
-            Log.d(TAG, "Got NFC adpater");
-            int counter = 0;
-            while ((!mNfcAdapter.isEnabled() && counter < 5)) {
-                Log.d(TAG, "nfc turn on wait: " + counter);
+           // mNfcAdapter.disableForegroundDispatch(this);
+            if (mNfcAdapter !=null) {
+                Log.d(TAG, "Got NFC adpater");
+                int counter = 0;
                 try {
-                    // quick and very dirty
-                    Thread.sleep(1000);
-                } catch (Exception e) {
-                    //
-                }
-                counter++;
-            }
-
-
-            //mNfcAdapter.disableReaderMode(WearActivity.this);
-            Log.d(TAG, "About to discover tag");
-            tag_discovered = false;
-            mNfcAdapter.enableReaderMode(WearActivity.this, new NfcAdapter.ReaderCallback() {
-                @Override
-                public void onTagDiscovered(Tag tag) {
-                    if (!tag_discovered) {
-                        tag_discovered = true;
-                        Log.d(TAG, "NFC tag discovered - going to read data");
-                        new NfcVReaderTask().execute(tag);
-                        // mNfcAdapter.disableReaderMode(WearActivity.this); // this seems to make it less reliable than multiple discoveries
-                    } else {
-                        Log.d(TAG, "Tag already discovered!");
+                    // null pointer can trigger here from the systemapi
+                    while ((!mNfcAdapter.isEnabled() && counter < 9)) {
+                        Log.d(TAG, "nfc turn on wait: " + counter);
+                        try {
+                            // quick and very dirty
+                            Thread.sleep(1000);
+                        } catch (Exception e) {
+                            //
+                        }
+                        counter++;
                     }
+
+
+                //mNfcAdapter.disableReaderMode(WearActivity.this);
+                Log.d(TAG, "About to discover tag");
+                tag_discovered = false;
+                mNfcAdapter.enableReaderMode(WearActivity.this, new NfcAdapter.ReaderCallback() {
+                    @Override
+                    public void onTagDiscovered(Tag tag) {
+                        if (!tag_discovered) {
+                            tag_discovered = true;
+                            Log.d(TAG, "NFC tag discovered - going to read data");
+                            new NfcVReaderTask().execute(tag);
+                            // mNfcAdapter.disableReaderMode(WearActivity.this); // this seems to make it less reliable than multiple discoveries
+                        } else {
+                            Log.d(TAG, "Tag already discovered!");
+                        }
+                    }
+                }, NfcAdapter.FLAG_READER_NFC_V | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK | NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS, null);
+                } catch (NullPointerException e)
+                {
+                    Log.wtf(TAG,"Null pointer exception from NFC subsystem: "+e.toString());
+                    // TODO do we actually need to reboot watch here after some counter of failures without resolution?
                 }
-            }, NfcAdapter.FLAG_READER_NFC_V | NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK | NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS, null);
-
-
+            } else {
+                Log.e(TAG,"nfcAdapter is NULL!!");
+            }
             // If NFC reading hasn't been completed within 10 seconds, close the app.
             mHandler.postDelayed(mStopActivityRunnable, 10000);
         } else {
@@ -208,17 +240,18 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
     @Override
     protected void onStop() {
         Log.i(TAG, "onStop");
-        mHandler.removeCallbacksAndMessages(null);
-        if ((mWakeLock != null) && (mWakeLock.isHeld())) mWakeLock.release();
+        if (mHandler != null) mHandler.removeCallbacksAndMessages(null);
+
         if (mVibrator != null) mVibrator.cancel();
         if (mNfcAdapter != null) {
             mNfcAdapter.disableReaderMode(this);
-            rootSwitchNFC(false);
         }
-        if (mGoogleApiClient.isConnected()) {
+        if ((mGoogleApiClient != null) && (mGoogleApiClient.isConnected())) {
             Wearable.MessageApi.removeListener(mGoogleApiClient, this);
             mGoogleApiClient.disconnect();
         }
+        rootSwitchNFC(false, 15000);
+        if ((mWakeLock != null) && (mWakeLock.isHeld())) mWakeLock.release();
         finish();
         super.onStop();
     }
@@ -246,7 +279,7 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
     private void sendStatusUpdate(Type type) {
         int attempt = PreferencesUtil.getRetries(this);
         Status status = new Status(type, attempt, WearActivity.MAX_ATTEMPTS,
-                AlarmReceiver.getNextCheck(mGoogleApiClient.getContext()));
+                AlarmReceiver.getNextCheck(mGoogleApiClient.getContext()),batteryLevel,isHasRoot());
         sendStatusUpdate(type, status);
     }
 
@@ -304,20 +337,138 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
         Log.e(TAG, "onConnectionFailed(): Failed to connect, with result: " + connectionResult);
     }
 
+    private synchronized boolean detectRoot()
+    {
+        checkedForRoot=true;
+        return (new File("/system/xbin/su").exists());
+    }
+    private boolean isHasRoot()
+    {
+        if (!checkedForRoot) hasRoot = detectRoot();
+        return hasRoot;
+    }
+
+    private void createScripts()
+    {
+        if (scripts_created) return;
+        // switches to lowest possible power levels on cpu
+        String script_name = getFilesDir()+"/powersave.sh";
+        writeToFile(script_name,"echo powersave > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor\necho 0 >/sys/devices/system/cpu/cpu1/online\n",getApplicationContext());
+
+        // restore cpu speed somewhat
+        script_name = getFilesDir()+"/performance.sh";
+        writeToFile(script_name,"echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor\necho 1 >/sys/devices/system/cpu/cpu1/online\n",getApplicationContext());
+
+
+        // disables the touch sense on the keypad by nuking the driver
+        script_name=getFilesDir()+"/killtouch.sh";
+        writeToFile(script_name,"echo synaptics_dsx.0 >/sys/bus/platform/drivers/synaptics_dsx/unbind\n" +
+                "a=`grep -l ^/system/bin/key_sleep_vibrate_service /proc/*/cmdline`\n" +
+                "if [ \"$a\" != \"\" ]\n" +
+                "then\n" +
+                "let p=6\n" +
+                "while [ $p -lt 14 ] && [ \"${a:$p:1}\" != \"/\" ] \n" +
+                "do\n" +
+                "let p=$p+1\n" +
+                "done\n" +
+                "let l=$p-6\n" +
+                "b=\"${a:6:$l}\"\n" +
+                "echo \"$b\"\n" +
+                "kill \"$b\"\n" +
+                "fi\n" +
+                "\n",getApplicationContext());
+
+
+        scripts_created = true;
+    }
+
+    private void writeToFile(String filename,String data,Context context) {
+        try {
+            File the_file = new File(filename);
+           // if (!the_file.exists())
+          //  {
+                FileOutputStream out = new FileOutputStream(the_file);
+                out.write(data.getBytes(Charset.forName("UTF-8")));
+                out.close();
+           // }
+        }
+        catch (IOException e) {
+            Log.e(TAG, "File write failed: " + e.toString());
+        }
+    }
+    private void rootSwitchNFC(boolean state)
+    {
+        rootSwitchNFC(state,0);
+    }
     // platform specific method for enabling/disabling nfc - not sure if there is a better api based method
-    private static void rootSwitchNFC(final boolean state) {
-        Log.d(TAG, "Setting NFC hardware to state: " + (state ? "ON" : "OFF"));
+    private void rootSwitchNFC(final boolean state, final long delay) {
+        nfcDestinationState=state;
+        Log.d(TAG, "Setting NFC hardware to state: " + (state ? "ON" : "OFF") + ((delay==0) ? " now" : " after: "+delay));
         new Thread() {
             @Override
             public void run() {
+                final PowerManager pm = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
+                PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Nfc-control");
+                wl.acquire(30000);
                 try {
-                    final boolean needs_root = true; // unclear at the moment whether we need root for this
-                    final Process execute = Runtime.getRuntime().exec((needs_root ? "su -c " : "")+"service call nfc " + (state ? "6" : "5")); // turn NFC on or off
+                    if (delay>0)
+                    {
+                        Log.d(TAG,"Sleeping for "+delay+" ms");
+                        Thread.sleep(delay);
+                        Log.d(TAG,"Sleep finished");
+                    }
+                    if ((nfcDestinationState!=null)&&(nfcDestinationState!=state))
+                    {
+                        Log.e(TAG,"Destination state changed from: "+state+" to "+nfcDestinationState+" .. skipping switch!");
+                    } else {
+                        //final boolean needs_root = true; // unclear at the moment whether we need root for this
+
+                        if (state)
+                        {
+                            if (d) Log.d(TAG,"Switching to higher performance cpu speed");
+                            final Process execute4 = Runtime.getRuntime().exec("su -c sh "+getFilesDir()+"/performance.sh");
+                        }
+
+                        for (int counter=0;counter<5;counter++) {
+                            final Process execute = Runtime.getRuntime().exec("su -c service call nfc " + (state ? "6" : "5")); // turn NFC on or off
+                            if (showProcessOutput(execute) != null) {
+                                Log.e(TAG, "Got error- retrying.."+counter);
+                            } else {
+                               break;
+                            }
+                        }
+
+                        if (!state) {
+                            if (d) Log.d(TAG,"Switching to lower powersave cpu speed");
+                            String script_name = getFilesDir() + "/powersave.sh";
+                            final Process execute2 = Runtime.getRuntime().exec("su -c sh " + script_name);
+
+                       if (d) showProcessOutput(execute2);
+                         }
+                    }
+
                 } catch (Exception e) {
-                    Log.e(TAG, "Got exception executing root nfc off");
+                    Log.e(TAG, "Got exception executing root nfc off: "+e.toString());
+                } finally {
+                    if (wl.isHeld()) wl.release();
                 }
             }
         }.start();
+    }
+
+    private static String showProcessOutput(Process execute)
+    {
+            try {
+                Thread.sleep(1000);
+                if (d) Log.d(TAG, "PROCESS OUTPUT: " + (new BufferedReader(new InputStreamReader(execute.getInputStream())).readLine()));
+                String error = (new BufferedReader(new InputStreamReader(execute.getErrorStream())).readLine());
+                if (d) Log.d(TAG, " PROCESS ERROR: " + error);
+                return error;
+            } catch (InterruptedException | IOException e)
+            {
+                Log.d(TAG,"Got error showing process output: "+e.toString());
+            }
+        return "other error";
     }
 
     private class NfcVReaderTask extends AsyncTask<Tag, Void, Tag> {
@@ -327,9 +478,9 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
         @Override
         protected void onPostExecute(Tag tag) {
             try {
-                Log.d(TAG, "NFC Reader task done - disabling read mode");
+                if (d) Log.d(TAG, "NFC Reader task done - disabling read mode");
                 mNfcAdapter.disableReaderMode(WearActivity.this);
-                Log.d(TAG, "NFC read mode disabled");
+                if (d) Log.d(TAG, "NFC read mode disabled");
                 if (tag == null) return;
                 String tagId = bytesToHexString(tag.getId());
                 int attempt = PreferencesUtil.getRetries(WearActivity.this);
@@ -361,7 +512,7 @@ public class WearActivity extends Activity implements ConnectionCallbacks,
         protected Tag doInBackground(Tag... params) {
             Tag tag = params[0];
             NfcV nfcvTag = NfcV.get(tag);
-            Log.d(TAG, "Attempting to read tag data");
+            if (d) Log.d(TAG, "Attempting to read tag data");
             try {
                 nfcvTag.connect();
                 final byte[] uid = tag.getId();

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlertRules.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlertRules.java
@@ -12,8 +12,11 @@ public class AlertRules {
 
     public static Danger check(Context context, PredictionData data) {
         Danger danger = Danger.NOTHING;
-        if (!alertSnoozeHigh(context)) danger = alertHigh(context, data);
-        if (!alertSnoozeLow(context) && danger == Danger.NOTHING) danger = alertLow(context, data);
+        if (!allAlertsDisabled(context)) {
+            if (!alertSnoozeHigh(context)) danger = alertHigh(context, data);
+            if (!alertSnoozeLow(context) && danger == Danger.NOTHING)
+                danger = alertLow(context, data);
+        }
         return danger;
     }
 
@@ -21,6 +24,12 @@ public class AlertRules {
         Danger danger = alertHigh(context, data);
         if (danger == Danger.NOTHING) danger = alertLow(context, data);
         return danger;
+    }
+
+    private static boolean allAlertsDisabled(Context context)
+    {
+        // Booleans can be either boolean or text depending on whether they are on watch or phone due to how they are synced
+        return PreferencesUtil.getBoolean(context, context.getString(R.string.key_all_alarms_disabled), false);
     }
 
     private static boolean alertSnoozeHigh(Context context) {

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlertRules.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlertRules.java
@@ -28,7 +28,6 @@ public class AlertRules {
 
     private static boolean allAlertsDisabled(Context context)
     {
-        // Booleans can be either boolean or text depending on whether they are on watch or phone due to how they are synced
         return PreferencesUtil.getBoolean(context, context.getString(R.string.key_all_alarms_disabled), false);
     }
 

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
@@ -37,6 +37,10 @@ public class AlgorithmUtil {
         return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF) / 10;
     }
 
+    private static int getGlucoseRaw(byte[] bytes) {
+        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF); // 0x3FFF or 0x0FFF ?
+    }
+
     public static TrendArrow getTrendArrow(GlucoseData data) {
         if (data instanceof PredictionData) {
             PredictionData predictionData = (PredictionData) data;
@@ -73,6 +77,7 @@ public class AlgorithmUtil {
 
         ArrayList<GlucoseData> historyList = new ArrayList<>();
 
+
         // loads history values (ring buffer, starting at index_trent. byte 124-315)
         for (int index = 0; index < 32; index++) {
             int i = indexHistory - index - 1;
@@ -80,6 +85,9 @@ public class AlgorithmUtil {
             GlucoseData glucoseData = new GlucoseData();
             glucoseData.glucoseLevel =
                     getGlucose(new byte[]{data[(i * 6 + 125)], data[(i * 6 + 124)]});
+
+            glucoseData.glucoseLevelRaw =
+                    getGlucoseRaw(new byte[]{data[(i * 6 + 125)], data[(i * 6 + 124)]});
 
             int time = Math.max(0, Math.abs((sensorTime - 3) / 15) * 15 - index * 15);
 
@@ -99,6 +107,9 @@ public class AlgorithmUtil {
             GlucoseData glucoseData = new GlucoseData();
             glucoseData.glucoseLevel =
                     getGlucose(new byte[]{data[(i * 6 + 29)], data[(i * 6 + 28)]});
+
+            glucoseData.glucoseLevelRaw =
+                    getGlucoseRaw(new byte[]{data[(i * 6 + 29)], data[(i * 6 + 28)]});
             int time = Math.max(0, sensorTime - index);
 
             glucoseData.realDate = sensorStartTime + time * MINUTE;

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/GlucoseData.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/GlucoseData.java
@@ -8,6 +8,7 @@ public class GlucoseData implements Comparable<GlucoseData> {
     public String sensorId;
     public long sensorTime;
     public int glucoseLevel = -1;
+    public int glucoseLevelRaw = -1;
     public long phoneDatabaseId;
 
     public GlucoseData(){}

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/PreferencesUtil.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/PreferencesUtil.java
@@ -77,7 +77,16 @@ public class PreferencesUtil {
     public static void resetErrorsInARow(Context context) {
         setInt(context, "errors_in_a_row", 0);
     }
-    // End used in watch
+
+    public static Boolean slowCpu(Context context) {
+        return getBoolean(context, context.getString(R.string.pref_key_clock_speed));
+    }
+
+    public static Boolean disableTouchscreen(Context context) {
+        return getBoolean(context, context.getString(R.string.pref_key_disable_touchscreen));
+    }
+
+    /// / End used in watch
 
     public static void setBoolean(Context context, String key, boolean value) {
         PreferenceManager.getDefaultSharedPreferences(context).edit().putBoolean(key, value).apply();

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/PreferencesUtil.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/PreferencesUtil.java
@@ -18,6 +18,11 @@ public class PreferencesUtil {
         return getBoolean(context, "ns_rest");
     }
 
+    // Used on phone
+    public static Boolean isXdripPlusEnabled(Context context) {
+        return getBoolean(context, "xdrip_plus_broadcast");
+    }
+
     public static String getNsRestUrl(Context context) {
         return getString(context, "ns_rest_uri");
     }
@@ -83,7 +88,12 @@ public class PreferencesUtil {
     }
 
     public static boolean getBoolean(Context context, String key, boolean default_) {
-        return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(key, default_);
+        // booleans get stored on watch as strings due to the way data is synced
+        try {
+            return PreferenceManager.getDefaultSharedPreferences(context).getBoolean(key, default_);
+        } catch (ClassCastException e) {
+            return PreferencesUtil.getString(context, key).equals("true");
+        }
     }
 
     public static void setInt(Context context, String key, int value) {

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/Status.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/Status.java
@@ -18,12 +18,23 @@ public class Status {
     public long nextCheck;
     public int alarmExtraValue;
     public int alarmExtraTrendOrdinal;
+    public int battery;
+    public boolean hasRoot;
 
     public Status(Type type, int attempt, int maxAttempts, long nextCheck) {
         this.status = type;
         this.attempt = attempt;
         this.maxAttempts = maxAttempts;
         this.nextCheck = nextCheck;
+    }
+
+    public Status(Type type, int attempt, int maxAttempts, long nextCheck, int battery, boolean has_root) {
+        this.status = type;
+        this.attempt = attempt;
+        this.maxAttempts = maxAttempts;
+        this.nextCheck = nextCheck;
+        this.battery = battery;
+        this.hasRoot = has_root;
     }
 
     public Status(Type type, int attempt, int maxAttempts, long nextCheck, int alarmExtraValue,

--- a/shareddata/src/main/res/values/base-strings.xml
+++ b/shareddata/src/main/res/values/base-strings.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <resources>
+    <string name="key_all_alarms_disabled">all_alarms_disabled</string>
+    <string name="pref_key_clock_speed">pref_key_clock_speed</string>
+    <string name="pref_key_disable_touchscreen">pref_key_disable_touchscreen</string>
     <string name="key_snooze_high">postpone_high</string>
     <string name="key_snooze_low">postpone_low</string>
     <string name="key_alarm_limit_high">alarm_level_high</string>


### PR DESCRIPTION
Here is the current version I am using with xDrip+ It works really well in my tests so far.

What this does:
- Adds an optional local broadcast of the data which is received by xDrip+ facilitating the data feed
- Adds watch battery level reporting to the app
- Adds power saving options for the watchface, including disabling the NFC when not in use, adjusting the CPU clock speed and active cores and completely disabling the touch screen driver.
- Adds support for detecting/reporting root which is needed for the above power saving functions.
- Additional preference option to disable all alarms (watch/phone) when using xDrip+

xDrip+ uses the raw value from the sensor and so I have extended the protocol to include this data  as well as battery level and root status.

I consider the original LibreAlarm code to be pretty elegant. My new code for handling the root features is much less elegant. 

One reason for this is that, for example, the NFC subsystem is inconsistent in processing requests and its timings and the implemented code flow is the most reliable method I found interacting with it. The root power saving features were added with a rapid prototyping phase where I had to experiment to find what would actually work.

Another example is that when the synaptics touchscreen driver is disabled at the kernel level this upsets once service which we then have to restart to avoid runaway cpu usage.

Please let me know what you think of these changes?

Thanks. Jon
