### PR TITLE
Use multi-block reading mode and better mask

### DIFF
--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
@@ -36,11 +36,13 @@ public class AlgorithmUtil {
     }
 
     private static int getGlucose(byte[] bytes) {
-        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF) / 10;
+        //return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF) / 10; // should be discussed/tested
+        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF) / 10;
     }
 
     private static int getGlucoseRaw(byte[] bytes) {
-        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF);
+        //return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF); // should be discussed/tested
+        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF);
     }
 
     public static TrendArrow getTrendArrow(GlucoseData data) {

--- a/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
+++ b/shareddata/src/main/java/com/pimpimmobile/librealarm/shareddata/AlgorithmUtil.java
@@ -36,11 +36,11 @@ public class AlgorithmUtil {
     }
 
     private static int getGlucose(byte[] bytes) {
-        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF) / 10;
+        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF) / 10;
     }
 
     private static int getGlucoseRaw(byte[] bytes) {
-        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x3FFF); // 0x3FFF or 0x0FFF ?
+        return ((256 * (bytes[0] & 0xFF) + (bytes[1] & 0xFF)) & 0x0FFF);
     }
 
     public static TrendArrow getTrendArrow(GlucoseData data) {


### PR DESCRIPTION
The PR adds multi-block reading mode (enabled by default in the code) which reduces the number of required NFC transactions by a factor of 3. In other tests I have done this significantly speeds up reading and reduces the chance for transaction errors and should also save battery.

As discussed previously, this PR there is a new mask of 0x0FFF when converting values. With the conversion algorithm currently in place this would give a max value of 409mg/dl or approx 22 mmol. 

I think this is quite close to the upper value the sensor can report and without this I think there can be incorrect random high values reported. 

Please let me know what you think? I have seen the 0x0FFF mask used in other similar apps but I don't know whether at high levels this is correct or whether it will "wrap around" to a lower value. This would need testing, but that is difficult!

I have left that item commented out of the code for now as it is a very significant change.
